### PR TITLE
add plugin-di to index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -27,6 +27,7 @@
   "@elizaos-plugins/plugin-cosmos": "github:elizaos-plugins/plugin-cosmos",
   "@elizaos-plugins/plugin-cronoszkevm": "github:elizaos-plugins/plugin-cronoszkevm",
   "@elizaos-plugins/plugin-depin": "github:elizaos-plugins/plugin-depin",
+  "@elizaos-plugins/plugin-di": "github:elizaos-plugins/plugin-di",
   "@elizaos-plugins/plugin-echochambers": "github:elizaos-plugins/plugin-echochambers",
   "@elizaos-plugins/plugin-evm": "github:elizaos-plugins/plugin-evm",
   "@elizaos-plugins/plugin-ferePro": "github:elizaos-plugins/plugin-ferePro",


### PR DESCRIPTION
Add the missing plugin-di.

By the way, may I be the maintainer of these two plugins since I am mainly the author of these two plugins

- https://github.com/elizaos-plugins/plugin-flow
- https://github.com/elizaos-plugins/plugin-di

And I see that their package names haven't been changed yet.

Another question is whether the registry can support plugins that are not under the name of @elizaos-plugins?